### PR TITLE
Fix Code must be None or str

### DIFF
--- a/zapier/CHANGELOG.md
+++ b/zapier/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.5.0
+
+### Enhancements
+
+- Replace the error `Code must be None or str, got dict` to a more readable error. [#7](https://github.com/tidbcloud/ecosystem-integrations/pull/7)
+
 ## 0.4.0
 
 ### Bug Fixes

--- a/zapier/creates/row.js
+++ b/zapier/creates/row.js
@@ -11,7 +11,7 @@ const perform = async (z, bundle) => {
 
   const [rows, error] = await query(host, user, port, tidbPassword, database, `show columns from ${table}`)
   if (error) {
-    throw new z.errors.Error('Execute SQL error', error, 400)
+    throw new z.errors.Error(`Execute SQL error: ${error}`)
   }
 
   const data = []
@@ -46,7 +46,7 @@ const perform = async (z, bundle) => {
     data,
   )
   if (error2) {
-    throw new z.errors.Error('Execute SQL error', error2, 400)
+    throw new z.errors.Error(`Execute SQL error: ${error2}`)
   }
 
   return Object.create(null)
@@ -66,7 +66,7 @@ const rowFields = async (z, bundle) => {
 
   const [rows, error] = await query(host, user, port, tidbPassword, database, `show columns from ${table}`)
   if (error) {
-    throw new z.errors.Error('Execute SQL error', error, 400)
+    throw new z.errors.Error(`Execute SQL error: ${error}`)
   }
 
   const result = []

--- a/zapier/creates/row_update.js
+++ b/zapier/creates/row_update.js
@@ -11,7 +11,7 @@ const perform = async (z, bundle) => {
 
   const [rows, error] = await query(host, user, port, tidbPassword, database, `show columns from ${table}`)
   if (error) {
-    throw new z.errors.Error('Execute SQL error', error, 400)
+    throw new z.errors.Error(`Execute SQL error: ${error}`)
   }
 
   let sql = `update ${table} set `
@@ -34,7 +34,7 @@ const perform = async (z, bundle) => {
 
   const [_, error1] = await query(host, user, port, tidbPassword, database, sql)
   if (error1) {
-    throw new z.errors.Error('Execute SQL error', error1, 400)
+    throw new z.errors.Error(`Execute SQL error: ${error1}`)
   }
 
   return Object.create(null)
@@ -87,7 +87,7 @@ const rowFields = async (z, bundle) => {
 
   const [rows, error] = await query(host, user, port, tidbPassword, database, `show columns from ${table}`)
   if (error) {
-    throw new z.errors.Error('Execute SQL error', error, 400)
+    throw new z.errors.Error(`Execute SQL error: ${error}`)
   }
 
   const result = []

--- a/zapier/package-lock.json
+++ b/zapier/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zapier-tidbcloud",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "zapier-tidbcloud",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "dependencies": {
         "mysql": "^2.18.1",
         "mysql2": "^2.3.3",

--- a/zapier/package.json
+++ b/zapier/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zapier-tidbcloud",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/zapier/resources/column.js
+++ b/zapier/resources/column.js
@@ -10,7 +10,7 @@ const performList = async (z, bundle) => {
 
   const [rows, error] = await query(host, user, port, tidbPassword, database, `show columns from ${table}`)
   if (error) {
-    throw new z.errors.Error('Execute SQL error', error, 400)
+    throw new z.errors.Error(`Execute SQL error: ${error}`)
   }
 
   const result = []

--- a/zapier/resources/database.js
+++ b/zapier/resources/database.js
@@ -9,7 +9,7 @@ const performList = async (z, bundle) => {
 
   const [rows, error] = await query(host, user, port, tidbPassword, null, `show databases`)
   if (error) {
-    throw new z.errors.Error('Execute SQL error', error, 400)
+    throw new z.errors.Error(`Execute SQL error: ${error}`)
   }
 
   const result = []
@@ -43,7 +43,7 @@ const performCreate = async (z, bundle) => {
     `create database if not exists ${bundle.inputData.database}`,
   )
   if (error) {
-    throw new z.errors.Error('Execute SQL error', error, 400)
+    throw new z.errors.Error(`Execute SQL error: ${error}`)
   }
   return {
     database: bundle.inputData.database,
@@ -59,7 +59,7 @@ const performSearch = async (z, bundle) => {
 
   const [rows, error] = await query(host, user, port, tidbPassword, null, `show databases`)
   if (error) {
-    throw new z.errors.Error('Execute SQL error', error, 400)
+    throw new z.errors.Error(`Execute SQL error: ${error}`)
   }
   for (let i = 0; i < rows.length; i++) {
     if (rows[i].Database === bundle.inputData.database) {

--- a/zapier/resources/table.js
+++ b/zapier/resources/table.js
@@ -17,7 +17,7 @@ const performList = async (z, bundle) => {
     `select tidb_table_id,table_name from information_schema.tables where table_schema='${bundle.inputData.database}'`,
   )
   if (error) {
-    throw new z.errors.Error('Execute SQL error', error, 400)
+    throw new z.errors.Error(`Execute SQL error: ${error}`)
   }
 
   const result = []
@@ -37,7 +37,7 @@ const performCreate = async (z, bundle) => {
 
   const [rows, error] = await query(host, user, port, tidbPassword, database, `${bundle.inputData.tableDDL}`)
   if (error) {
-    throw new z.errors.Error('Execute SQL error', error, 400)
+    throw new z.errors.Error(`Execute SQL error: ${error}`)
   }
 
   return Object.create(null)
@@ -60,7 +60,7 @@ const performSearch = async (z, bundle) => {
     `select table_name from information_schema.tables where table_schema='${bundle.inputData.database}' and table_name='${bundle.inputData.table}'`,
   )
   if (error) {
-    throw new z.errors.Error('Execute SQL error', error, 400)
+    throw new z.errors.Error(`Execute SQL error: ${error}`)
   }
   if (rows.length !== 0) {
     return [{ table: rows[0].table_name }]

--- a/zapier/searches/row.js
+++ b/zapier/searches/row.js
@@ -19,7 +19,7 @@ const perform = async (z, bundle) => {
     [bundle.inputData.lookup_value],
   )
   if (error) {
-    throw new z.errors.Error('Execute SQL error', error, 400)
+    throw new z.errors.Error(`Execute SQL error: ${error}`)
   }
 
   return rows

--- a/zapier/searches/row_query.js
+++ b/zapier/searches/row_query.js
@@ -9,7 +9,7 @@ const perform = async (z, bundle) => {
 
   const [rows, error] = await queryWithTimeOut(host, user, port, tidbPassword, null, 30, bundle.inputData.query)
   if (error) {
-    throw new z.errors.Error('Execute SQL error', error, 400)
+    throw new z.errors.Error(`Execute SQL error: ${error}`)
   }
 
   return rows

--- a/zapier/tidb_client/PromiseClient.js
+++ b/zapier/tidb_client/PromiseClient.js
@@ -41,7 +41,7 @@ async function query(host, user, port, password, database, sql, values) {
     const [rows, filed] = await connection.execute(sql, values)
     return [rows, undefined]
   } catch (error) {
-    return [undefined, error]
+    return [undefined, error.message]
   } finally {
     if (connection) {
       await connection.end()

--- a/zapier/tidb_client/PromiseClientWithTimeout.js
+++ b/zapier/tidb_client/PromiseClientWithTimeout.js
@@ -49,7 +49,7 @@ async function queryWithTimeOut(host, user, port, password, database, timeout, s
     const [rows, filed] = await promisePool.execute(sql, values)
     return [rows, undefined]
   } catch (error) {
-    return [undefined, error]
+    return [undefined, error.message]
   } finally {
     if (promisePool) {
       await promisePool.end()

--- a/zapier/triggers/row.js
+++ b/zapier/triggers/row.js
@@ -23,7 +23,7 @@ const perform = async (z, bundle) => {
                    where table_name = '${table}'`,
     )
     if (error) {
-      throw new z.errors.Error('Execute SQL error', error, 400)
+      throw new z.errors.Error(`Execute SQL error: ${error}`)
     }
     // use pk/uk or the first key as dedupe_key
     dedupe_key = columns[0].COLUMN_NAME
@@ -54,7 +54,7 @@ const perform = async (z, bundle) => {
                    and COLUMN_NAME = 'id';`,
   )
   if (error2) {
-    throw new z.errors.Error('Execute SQL error', error2, 400)
+    throw new z.errors.Error(`Execute SQL error: ${error2}`)
   }
   let has_id_column = id.length > 0
 
@@ -74,7 +74,7 @@ const perform = async (z, bundle) => {
 
   const [rows, error] = await query(host, user, port, tidbPassword, database, sql)
   if (error) {
-    throw new z.errors.Error('Execute SQL error', error, 400)
+    throw new z.errors.Error(`Execute SQL error: ${error}`)
   }
 
   // do dedupe. Zapier will throw error when got a two or more results with the same id

--- a/zapier/triggers/row_query.js
+++ b/zapier/triggers/row_query.js
@@ -10,7 +10,7 @@ const perform = async (z, bundle) => {
   const limitQuery = `select * from (${bundle.inputData.query}) as fake_table limit 1000000`
   const [rows, error] = await queryWithTimeOut(host, user, port, tidbPassword, null, 30, limitQuery)
   if (error) {
-    throw new z.errors.Error('Execute SQL error', error, 400)
+    throw new z.errors.Error(`Execute SQL error: ${error}`)
   }
 
   if (rows.length === 0) {


### PR DESCRIPTION
# Background

we will meet the following error when we config zap or the zap is running.

![7Q6GIreHFM](https://user-images.githubusercontent.com/52435083/208571038-e0662d41-22ac-4d11-87e4-5444d0ce52c8.jpg)

# Resolved

It is because of  z.error.Error accepts none or str in the second parameter, not a dict.
```
throw new z.errors.Error('Execute SQL error', error, 400)
```